### PR TITLE
Api 53 query parameters

### DIFF
--- a/rules/jsonapi-member-names.js
+++ b/rules/jsonapi-member-names.js
@@ -1,0 +1,34 @@
+// Document Structure - Links - https://jsonapi.org/format/1.0/#document-member-names
+
+// All rules in this file MUST have corresponding tests
+
+
+import { enumeration, pattern, casing} from '@stoplight/spectral-functions';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+export default {
+  documentationUrl: 'https://jsonapi.org/format/1.0/#document-member-names',
+  rules: {
+    'member-names': {
+      description: 'Implementation specific query parameters MUST adhere to the same constraints as member names along with additional requirements.',
+      message: '{{path}} - {{description}}',
+      severity: DiagnosticSeverity.Error, // error
+      // query may be more like a POST https://dev.wix.com/api/rest/members/members/query-members
+      // given: "$.paths[*][get]",   // "$..properties[?(@property === 'query')]",
+      given: [
+        "$.paths[*][get].parameters.name",
+        "$.paths[*][get].parameters[*].name"
+      ],
+      then: {
+        //field: "@key", //The value can also be @key to apply the rule to the keys of an object.
+        function: pattern, //I want to apply ALL Matches listed below to ALL Members
+        functionOptions: {
+          // 4 regex may have to be expanded to 4 rules
+          Match: "^[a-zA-Z0-9]",
+          Match: "[a-zA-Z0-9]$",
+          Match: "[a-zA-Z0-9-_]"
+        }
+      }
+    }
+  }
+};

--- a/rules/jsonapi-query-parameters.js
+++ b/rules/jsonapi-query-parameters.js
@@ -1,0 +1,94 @@
+// Document Structure - Links - https://jsonapi.org/format/1.0/#query-parameters
+// All rules in this file MUST have corresponding tests
+
+import { enumeration, pattern, casing} from '@stoplight/spectral-functions';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+console.log("in match logic");
+
+export default {
+  documentationUrl: 'https://jsonapi.org/format/1.0/#query-parameters',
+  rules: {
+    'get-filter-query-parameters': {
+      description: 'Implementation specific query parameters MUST adhere to the same constraints as member names ' +
+                   'with the additional requirement that they MUST contain at least one non a-z character, which ' +
+                   'is selected to be [-_A-Z].',
+      message: '{{path}} - {{description}}',
+
+      severity: DiagnosticSeverity.Error, // error
+
+      given: [
+        "$.paths[*][get].parameters.name",
+        "$.paths[*][get].parameters[*].name"
+      ],
+      // see "irmpove the quailit of you APIS adn descritipn https://stoplight.io/open-source/spectral"
+      then: {
+        field: "@key", // The value can also be @key to apply the rule to the keys of an object.
+        function: pattern, // I want to apply ALL Matches listed below to ALL Members
+        functionOptions: {
+          match: "[A-Z-_]", // 4 regex may have to be expanded to 4 rules
+        }
+      }
+    },
+
+    // documentationUrl: 'https://jsonapi.org/format/1.0/#document-member-names',
+    'member-names-begins_with': {
+      description: 'Implementation specific query parameters MUST adhere to the same constraints as member names along with additional requirements.',
+      message: '{{path}} - {{description}}',
+      severity: DiagnosticSeverity.Error, // error
+      // query may be more like a POST https://dev.wix.com/api/rest/members/members/query-members
+      // given: "$.paths[*][get]",   // "$..properties[?(@property === 'query')]",
+      given: [
+        "$.paths[*][get].parameters.name",
+        "$.paths[*][get].parameters[*].name"
+      ],
+      then: {
+        //field: "@key", //The value can also be @key to apply the rule to the keys of an object.
+        function: pattern, //I want to apply ALL Matches listed below to ALL Members
+        functionOptions: {
+          match: "^[a-zA-Z0-9]",
+        },
+
+      }
+    },
+
+        // documentationUrl: 'https://jsonapi.org/format/1.0/#document-member-names',
+        'member-names-end_with': {
+          description: 'Implementation specific query parameters MUST adhere to the same constraints as member names along with additional requirements.',
+          message: '{{path}} - {{description}}',
+          severity: DiagnosticSeverity.Error, // error
+          given: [
+            "$.paths[*][get].parameters.name",
+            "$.paths[*][get].parameters[*].name"
+          ],
+          then: {
+            //field: "@key", // The value can also be @key to apply the rule to the keys of an object.
+            function: pattern, // Want to apply ALL Matches listed below to ALL Members
+            functionOptions: {
+              match: "[a-zA-Z0-9]$",
+            },
+          }
+        },
+                // documentationUrl: 'https://jsonapi.org/format/1.0/#document-member-names',
+                'member-names-chars': {
+                  description: 'Implementation specific query parameters MUST adhere to the same constraints as member names along with additional requirements.',
+                  message: '{{path}} - {{description}}',
+                  severity: DiagnosticSeverity.Error, // error
+                  given: [
+                    "$.paths[*][get].parameters.name",
+                    "$.paths[*][get].parameters[*].name"
+                  ],
+                  then: {
+                    //field: "@key", // The value can also be @key to apply the rule to the keys of an object.
+                    function: pattern, // Want to apply ALL Matches listed below to ALL Members
+                    functionOptions: {
+                      match: "[a-zA-Z0-9-_]",
+                    },
+
+
+      }
+    }
+
+  }
+
+};

--- a/rules/jsonapi-query-ruleset.yaml
+++ b/rules/jsonapi-query-ruleset.yaml
@@ -1,0 +1,10 @@
+# Document Structure
+# https://jsonapi.org/format/1.0/#document-member-names
+# https://jsonapi.org/format/1.0/#query-parameters
+
+# *-ruleset.yaml files generally SHOULD NOT contain any testable rules.
+# all rules in this file MUST have corresponding tests.
+
+extends:
+  - jsonapi-member-names.js
+  - jsonapi-query-parameters.js

--- a/rules/jsonapi-ruleset.yaml
+++ b/rules/jsonapi-ruleset.yaml
@@ -6,3 +6,4 @@
 extends:
   - jsonapi-content-negotiation-ruleset.yaml
   - jsonapi-document-structure-ruleset.yaml
+  - jsonapi-query-ruleset.yaml

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -1,0 +1,512 @@
+import { expect } from 'chai';
+import spectralCore from '@stoplight/spectral-core';
+const { Spectral } = spectralCore;
+
+// rules under test
+import ruleset from '../rules/jsonapi-query-parameters.js';
+
+describe('jsonapi-query-parameters ruleset:', function () {
+
+  let spectral;
+
+  beforeEach(function () {
+
+    spectral = new Spectral();
+
+  });
+
+  // see test/assets/example-jsonapi-oas.yaml see filter and fields
+  // describe('get-filter-query-parameters:', function () {
+
+  it('the query fields/parameters should adhere to the specification', function (done) {
+
+    const doc = {
+      'openapi': '3.0.2',
+      'paths': {
+        '/myResources?{abcEfg}=22': {
+          'get': {
+            'parameters': {
+              'name': 'abcEfg',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              }
+            },
+            'responses': {
+              '200': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    spectral.setRuleset(ruleset);
+    spectral.run(doc)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}`);
+        expect(results.length).to.equal(0, 'Error count should be 0');
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+
+  // If a server encounters a query parameter that does not follow the naming
+  //   conventions above, and the server does not know how to process it as a
+  //   query parameter from this specification, it MUST return 400 Bad Request
+  // https://jsonapi.org/format/1.0/#query-parameters
+  it('the query should return a 400 Bad Request error if the parameters do not adhere to ' +
+     'the specification', function (done) {
+
+    const badDocument = {
+      'openapi': '3.0.2',
+      'paths': {
+        '/myResources?{abefg}=22': {
+          'get': {
+            'parameters': {
+              'name': 'abcefg',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              }
+            },
+
+            'responses': {
+              '400': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    spectral.setRuleset(ruleset);
+    spectral.run(badDocument)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}`);
+        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+
+  // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
+  it('the rule should pass with NO errors', function (done) {
+
+    const cleanDoc3 = {
+      'openapi': '3.0.2',
+      'paths': {
+        '/myResources?{abcEfg}=22&{a_b}=23': {
+
+          'get': {
+
+            'parameters': [{ 'name': 'abcEfg',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } },
+            { 'name': 'a_b',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } }],
+
+            'responses': {
+              '200': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    spectral.setRuleset(ruleset);
+    spectral.run(cleanDoc3)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}`);
+        expect(results.length).to.equal(0, 'Error count should be 0');
+
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+  // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
+  it('the rule should pass with errors, bad parameter name, paremeter name must have at ' +
+     'least one non a-z character, could be [-_A-Z]', function (done) {
+
+    const badDoc4 = {
+      'openapi': '3.0.2',
+      'paths': {
+        // second parameter is the bad one
+        '/myResources?{abcEfg}=22&{ab}=23': {
+
+          'get': {
+
+            'parameters': [{ 'name': 'abcEfg',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } },
+            // this parameter is a baddie
+            { 'name': 'ab',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } }],
+
+            'responses': {
+              '200': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    spectral.setRuleset(ruleset);
+    spectral.run(badDoc4)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}
+
+        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+  // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
+  it('the rule should pass with errors, bad parameter name, cannot be a number', function (done) {
+
+    const badDoc5 = {
+      'openapi': '3.0.2',
+      'paths': {
+        // second parameter is the bad one
+        '/myResources?{33}=22&{33}=23': {
+
+          'get': {
+
+            'parameters': [{ 'name': '33',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } },
+            // this parameter is the baddie
+            { 'name': '33',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } }],
+
+            'responses': {
+              '200': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+
+    spectral.setRuleset(ruleset);
+
+    spectral.run(badDoc5)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}`);
+
+        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+  it('the rule should pass with errors, bad parameter name, unallowed special character', function (done) {
+
+    const badDoc6 = {
+      'openapi': '3.0.2',
+      'paths': {
+        // second parameter is the bad one
+        "/myResources?{'A_-___'}=22&{'A_-__'}=23": {
+
+          'get': {
+
+            'parameters': [{ 'name': 'A_-___',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } },
+            // this parameter is the baddie
+            { 'name': 'A_-___',
+              'description': 'schema for \'fields\' query parameter',
+              'in': 'query',
+              'schema': {
+                'type': 'string'
+              } }],
+
+            'responses': {
+              '200': {
+                'content': {
+                  'application/vnd.api+json': {
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'jsonapi': {},
+                        'meta': {},
+                        'data:': {
+                          'type': 'object',
+                          'properties': {
+                            'meta': {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'patch': {
+            'requestBody': {
+              'content': {
+                'application/vnd.api+json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'jsonapi': {},
+                      'meta': {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    spectral.setRuleset(ruleset);
+
+    spectral.run(badDoc6)
+      .then((results) => {
+
+        // results: ${JSON.stringify(results, null, 2)}`);
+
+        expect(results[0].code).to.equal('member-names-end_with', 'Incorrect error');
+        done();
+
+      })
+      .catch((error) => {
+
+        done(error);
+
+      });
+
+  });
+
+});


### PR DESCRIPTION
API-53 Spectral Linting Rules - QueryParameters

please use Squash to squash the two commits into on and use the new comment below:

Spectral Linting Rules - QueryParameters
     
* Implements rules for https://jsonapi.org/format/1.0/#query-parameters
* Tests for above rules