### PR TITLE
API-59 Errors.ErrorObjects

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,7 @@ env:
 extends: "eslint:recommended"
 parserOptions:
   sourceType: "module"
+  ecmaVersion: 2021
   ecmaFeatures:
     jsx: false
 rules:

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -153,7 +153,7 @@ describe('jsonapi-query-parameters ruleset:', function () {
       expect(results.length).to.be.greaterThan(0, 'Error count should be greater than 0');
 
       // Check for severity
-      expect(result[0].severity).to.equal(DiagnosticSeverity.Error);
+      expect(results[0].severity).to.equal(DiagnosticSeverity.Error);
     } catch (error) {
       throw new Error(error);
     }

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -463,7 +463,7 @@ describe('jsonapi-query-parameters ruleset:', function () {
       expect(results.length).to.be.greaterThan(0, 'At least one error should be returned');
       
       // Check for the correct error code
-      expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error code');
+      expect(results[0].code).to.equal('member-names-end_with', 'Incorrect error code');
       
       // Optionally, check for severity level
       expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import spectralCore from '@stoplight/spectral-core';
+import { DiagnosticSeverity } from '@stoplight/types';
+
 const { Spectral } = spectralCore;
 
 // rules under test

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -6,33 +6,34 @@ const { Spectral } = spectralCore;
 import ruleset from '../rules/jsonapi-query-parameters.js';
 
 describe('jsonapi-query-parameters ruleset:', function () {
-
   let spectral;
 
+  // Common setup for all test cases
   beforeEach(function () {
-
     spectral = new Spectral();
-
+    spectral.setRuleset(ruleset);
   });
 
   // see test/assets/example-jsonapi-oas.yaml see filter and fields
   // describe('get-filter-query-parameters:', function () {
 
-  it('the query fields/parameters should adhere to the specification', function (done) {
-
-    const doc = {
+  // Test cases for valid query fields/parameters
+  it('should pass with no errors for valid query fields/parameters', async function () {
+    const validDocument = {
       'openapi': '3.0.2',
       'paths': {
-        '/myResources?{abcEfg}=22': {
+        '/myResources': {
           'get': {
-            'parameters': {
-              'name': 'abcEfg',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
+            'parameters': [
+              {
+                'name': 'abcEfg_A',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
               }
-            },
+            ],
             'responses': {
               '200': {
                 'content': {
@@ -74,21 +75,12 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    spectral.setRuleset(ruleset);
-    spectral.run(doc)
-      .then((results) => {
-
-        // results: ${JSON.stringify(results, null, 2)}`);
-        expect(results.length).to.equal(0, 'Error count should be 0');
-        done();
-
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+    try{
+      const results = await spectral.run(validDocument);
+      expect(results.length).to.equal(0, 'Error count should be 0');
+    } catch (error) {
+      throw new Error(error);
+    }
   });
 
 
@@ -96,23 +88,23 @@ describe('jsonapi-query-parameters ruleset:', function () {
   //   conventions above, and the server does not know how to process it as a
   //   query parameter from this specification, it MUST return 400 Bad Request
   // https://jsonapi.org/format/1.0/#query-parameters
-  it('the query should return a 400 Bad Request error if the parameters do not adhere to ' +
-     'the specification', function (done) {
-
-    const badDocument = {
+  // Test case for invalid parameter names
+  it('should return an error for invalid parameter names', async function () {
+    const documentWithInvalidParameterName = {
       'openapi': '3.0.2',
       'paths': {
-        '/myResources?{abefg}=22': {
+        '/myResources': {
           'get': {
-            'parameters': {
-              'name': 'abcefg',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
+            'parameters': [
+              {
+                'name': 'abcefg',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
               }
-            },
-
+            ],
             'responses': {
               '400': {
                 'content': {
@@ -154,47 +146,47 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    spectral.setRuleset(ruleset);
-    spectral.run(badDocument)
-      .then((results) => {
+    try{
+      const results = await spectral.run(documentWithInvalidParameterName);
 
-        // results: ${JSON.stringify(results, null, 2)}`);
-        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
-        done();
+      // Check for error length
+      expect(results.length).to.be.greaterThan(0, 'Error count should be greater than 0');
 
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+      // Check for severity
+      expect(result[0].severity).to.equal(DiagnosticSeverity.Error);
+    } catch (error) {
+      throw new Error(error);
+    }
   });
 
 
   // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
-  it('the rule should pass with NO errors', function (done) {
+  // Test case for query parameters with no errors
+  it('should pass with no errors for valid query parameters', async function () {
 
-    const cleanDoc3 = {
+    const validQueryParametersDocument = {
       'openapi': '3.0.2',
       'paths': {
-        '/myResources?{abcEfg}=22&{a_b}=23': {
-
+        '/myResources': {
           'get': {
-
-            'parameters': [{ 'name': 'abcEfg',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } },
-            { 'name': 'a_b',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } }],
-
+            'parameters': [
+              {
+                'name': 'abcEfg_A',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              },
+              {
+                'name': 'a_b',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              }
+            ],
             'responses': {
               '200': {
                 'content': {
@@ -236,52 +228,44 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    spectral.setRuleset(ruleset);
-    spectral.run(cleanDoc3)
-      .then((results) => {
-
-        // results: ${JSON.stringify(results, null, 2)}`);
-        expect(results.length).to.equal(0, 'Error count should be 0');
-
-        done();
-
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+    try{
+      const results = await spectral.run(validQueryParametersDocument);
+      expect(results.length).to.equal(0, 'Error count should be 0');
+    } catch (error){
+      throw new Error(error);
+    }
   });
 
   // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
-  it('the rule should pass with errors, bad parameter name, paremeter name must have at ' +
-     'least one non a-z character, could be [-_A-Z]', function (done) {
-
-    const badDoc4 = {
+  // test case for bad parameter name with one non a-z character
+  it('should return an error for bad parameter name with one non a-z character', async function () {
+    const badParameterNameDocument = {
       'openapi': '3.0.2',
       'paths': {
         // second parameter is the bad one
-        '/myResources?{abcEfg}=22&{ab}=23': {
-
+        '/myResources': {
           'get': {
-
-            'parameters': [{ 'name': 'abcEfg',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } },
-            // this parameter is a baddie
-            { 'name': 'ab',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } }],
-
+            'parameters': [
+              {
+                'name': 'abcEfg_A',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              },
+              // this parameter is a baddie
+              {
+                'name': 'ab@',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              }
+            ],
             'responses': {
-              '200': {
+              '400': {
                 'content': {
                   'application/vnd.api+json': {
                     'schema': {
@@ -321,51 +305,42 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    spectral.setRuleset(ruleset);
-    spectral.run(badDoc4)
-      .then((results) => {
+    try{
+      const results = await spectral.run(badParameterNameDocument);
 
-        // results: ${JSON.stringify(results, null, 2)}
+      // Check that an error is returned
+      expect(results.length).to.be.greaterThan(0, 'At least one error should be returned');
 
-        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
-        done();
+      // Check for the correct error code
+      expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error code');
 
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+      // Optionally, check for severity level
+      expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    } catch (error) {
+      throw new Error(error);
+    }
   });
 
   // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
-  it('the rule should pass with errors, bad parameter name, cannot be a number', function (done) {
-
-    const badDoc5 = {
+  // Test case for bad parameter name with a number
+  it('should return an error for bad parameter name with a number', async function () {
+    const badParameterNumberDocument = {
       'openapi': '3.0.2',
       'paths': {
-        // second parameter is the bad one
-        '/myResources?{33}=22&{33}=23': {
-
+        '/myResources': {
           'get': {
-
-            'parameters': [{ 'name': '33',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } },
-            // this parameter is the baddie
-            { 'name': '33',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } }],
-
+            'parameters': [
+              {
+                'name': '33',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              }
+            ],
             'responses': {
-              '200': {
+              '400': {
                 'content': {
                   'application/vnd.api+json': {
                     'schema': {
@@ -405,52 +380,41 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
+    try{
+      const results = await spectral.run(badParameterNumberDocument);
 
-    spectral.setRuleset(ruleset);
-
-    spectral.run(badDoc5)
-      .then((results) => {
-
-        // results: ${JSON.stringify(results, null, 2)}`);
-
-        expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error');
-        done();
-
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+      // Check that an error is returned
+      expect(results.length).to.be.greaterThan(0, 'At least one error should be returned');
+      
+      // Check for the correct error code
+      expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error code');
+      
+      // Optionally, check for severity level
+      expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    } catch (error) {
+      throw new Error (error);
+    }
   });
 
-  it('the rule should pass with errors, bad parameter name, unallowed special character', function (done) {
-
-    const badDoc6 = {
+  // Test case for bad parameter name with unallowed special characters
+  it('should return an error for bad parameter name with unallowed special characters', async function () {
+    const badParameterSpecialCharDocument = {
       'openapi': '3.0.2',
       'paths': {
-        // second parameter is the bad one
-        "/myResources?{'A_-___'}=22&{'A_-__'}=23": {
-
+        "/myResources": {
           'get': {
-
-            'parameters': [{ 'name': 'A_-___',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } },
-            // this parameter is the baddie
-            { 'name': 'A_-___',
-              'description': 'schema for \'fields\' query parameter',
-              'in': 'query',
-              'schema': {
-                'type': 'string'
-              } }],
-
+            'parameters': [
+              {
+                'name': 'A_-___',
+                'description': 'schema for \'fields\' query parameter',
+                'in': 'query',
+                'schema': {
+                  'type': 'string'
+                }
+              }
+            ],
             'responses': {
-              '200': {
+              '400': {
                 'content': {
                   'application/vnd.api+json': {
                     'schema': {
@@ -490,23 +454,23 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    spectral.setRuleset(ruleset);
-
-    spectral.run(badDoc6)
-      .then((results) => {
-
-        // results: ${JSON.stringify(results, null, 2)}`);
-
-        expect(results[0].code).to.equal('member-names-end_with', 'Incorrect error');
-        done();
-
-      })
-      .catch((error) => {
-
-        done(error);
-
-      });
-
+    try{
+      const results = await spectral.run(badParameterSpecialCharDocument);
+      
+      // Check that an error is returned
+      expect(results.length).to.be.greaterThan(0, 'At least one error should be returned');
+      
+      // Check for the correct error code
+      expect(results[0].code).to.equal('get-filter-query-parameters', 'Incorrect error code');
+      
+      // Optionally, check for severity level
+      expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    } catch (error) {
+      throw new Error(error);
+    }
   });
 
+
+
+  
 });

--- a/test/jsonapi-query-parameters.test.js
+++ b/test/jsonapi-query-parameters.test.js
@@ -8,12 +8,15 @@ const { Spectral } = spectralCore;
 import ruleset from '../rules/jsonapi-query-parameters.js';
 
 describe('jsonapi-query-parameters ruleset:', function () {
+
   let spectral;
 
   // Common setup for all test cases
   beforeEach(function () {
+
     spectral = new Spectral();
     spectral.setRuleset(ruleset);
+  
   });
 
   // see test/assets/example-jsonapi-oas.yaml see filter and fields
@@ -21,6 +24,7 @@ describe('jsonapi-query-parameters ruleset:', function () {
 
   // Test cases for valid query fields/parameters
   it('should pass with no errors for valid query fields/parameters', async function () {
+
     const validDocument = {
       'openapi': '3.0.2',
       'paths': {
@@ -77,12 +81,17 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(validDocument);
       expect(results.length).to.equal(0, 'Error count should be 0');
+    
     } catch (error) {
+
       throw new Error(error);
+    
     }
+  
   });
 
 
@@ -92,6 +101,7 @@ describe('jsonapi-query-parameters ruleset:', function () {
   // https://jsonapi.org/format/1.0/#query-parameters
   // Test case for invalid parameter names
   it('should return an error for invalid parameter names', async function () {
+
     const documentWithInvalidParameterName = {
       'openapi': '3.0.2',
       'paths': {
@@ -148,7 +158,8 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(documentWithInvalidParameterName);
 
       // Check for error length
@@ -156,9 +167,13 @@ describe('jsonapi-query-parameters ruleset:', function () {
 
       // Check for severity
       expect(results[0].severity).to.equal(DiagnosticSeverity.Error);
+    
     } catch (error) {
+
       throw new Error(error);
+    
     }
+  
   });
 
 
@@ -230,17 +245,23 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(validQueryParametersDocument);
       expect(results.length).to.equal(0, 'Error count should be 0');
-    } catch (error){
+    
+    } catch (error) {
+
       throw new Error(error);
+    
     }
+  
   });
 
   // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
   // test case for bad parameter name with one non a-z character
   it('should return an error for bad parameter name with one non a-z character', async function () {
+
     const badParameterNameDocument = {
       'openapi': '3.0.2',
       'paths': {
@@ -307,7 +328,8 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(badParameterNameDocument);
 
       // Check that an error is returned
@@ -318,14 +340,19 @@ describe('jsonapi-query-parameters ruleset:', function () {
 
       // Optionally, check for severity level
       expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    
     } catch (error) {
+
       throw new Error(error);
+    
     }
+  
   });
 
   // https://support.stoplight.io/s/article/Does-Stoplight-support-query-parameters
   // Test case for bad parameter name with a number
   it('should return an error for bad parameter name with a number', async function () {
+
     const badParameterNumberDocument = {
       'openapi': '3.0.2',
       'paths': {
@@ -382,7 +409,8 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(badParameterNumberDocument);
 
       // Check that an error is returned
@@ -393,17 +421,22 @@ describe('jsonapi-query-parameters ruleset:', function () {
       
       // Optionally, check for severity level
       expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    
     } catch (error) {
-      throw new Error (error);
+
+      throw new Error(error);
+    
     }
+  
   });
 
   // Test case for bad parameter name with unallowed special characters
   it('should return an error for bad parameter name with unallowed special characters', async function () {
+
     const badParameterSpecialCharDocument = {
       'openapi': '3.0.2',
       'paths': {
-        "/myResources": {
+        '/myResources': {
           'get': {
             'parameters': [
               {
@@ -456,7 +489,8 @@ describe('jsonapi-query-parameters ruleset:', function () {
       }
     };
 
-    try{
+    try {
+
       const results = await spectral.run(badParameterSpecialCharDocument);
       
       // Check that an error is returned
@@ -467,12 +501,14 @@ describe('jsonapi-query-parameters ruleset:', function () {
       
       // Optionally, check for severity level
       expect(results[0].severity).to.equal(DiagnosticSeverity.Error, 'Severity should be "Error"');
+    
     } catch (error) {
+
       throw new Error(error);
+    
     }
+  
   });
-
-
 
   
 });


### PR DESCRIPTION
feat: Add Spectral rules and tests for JSON:API error objects

This introduces a new set of Spectral rules specifically tailored for validating JSON:API error object structures within OpenAPI documents. Key highlights include:

- Creation of Spectral rules to ensure compliance with JSON:API standards, focusing on error object structures such as array structure, object properties, links, source, and meta-information.
- Development of a comprehensive OpenAPI test document that adheres to JSON:API specifications, particularly in defining error responses.
- Implementation of various utility functions to enhance the testing framework, including functions functions for setting up spectral, processing test rules, and dynamically managing rule sets based on test requirements. 
- Debugging and refinement of rules and test document structure to align with JSONPath expressions and Spectral's schema validation requirements.

These additions significantly improve our capability to automatically validate and ensure the consistency of API responses with the JSON:API standard.