### PR TITLE
Fix spelling errors in API-21

### DIFF
--- a/cliTest/documentStructure/resourceObjects/failing-rules.yaml
+++ b/cliTest/documentStructure/resourceObjects/failing-rules.yaml
@@ -1,5 +1,5 @@
 # This OpenAPI Document provides a way of testing rulesets using using Spectrals CLI Command. Covered ruleset include:
-#   - `jsonapi-errors-error-object.js` 
+#   - `jsonapi-document-structure-resource-objects.js` 
 #
 # Usage (From Repo Root Location):
 #   spectral lint cliTest/documentStructure/resourceObjects/failing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-objects.js

--- a/rules/jsonapi-document-structure-resource-objects.js
+++ b/rules/jsonapi-document-structure-resource-objects.js
@@ -1,11 +1,11 @@
-// Document Structure - Resource Objects - https://jsonapi.org/format/#document-resource-objects
+// Document Structure - Resource Objects - https://jsonapi.org/format/1.0/#document-resource-objects
 
 // All rules in the file MUST have corresponding tests
 
 import { enumeration, length, truthy } from '@stoplight/spectral-functions';
 
 export default {
-  documentationUrl: 'https://jsonapi.org/format/#document-resource-objects',
+  documentationUrl: 'https://jsonapi.org/format/1.0/#document-resource-objects',
   rules: {
 
     /**

--- a/rules/jsonapi-document-structure-ruleset.yaml
+++ b/rules/jsonapi-document-structure-ruleset.yaml
@@ -12,4 +12,4 @@ extends:
   - jsonapi-document-structure-meta-information.js
   - jsonapi-document-structure-links.js
   - jsonapi-document-structure-jsonapi-object.js
-  - jsonapi-document-structure-resource-object.js
+  - jsonapi-document-structure-resource-objects.js

--- a/test/jsonapi-document-structure-resource-objects.test.js
+++ b/test/jsonapi-document-structure-resource-objects.test.js
@@ -30,15 +30,21 @@ import invalidApiDocumentArrayTypeType from './docs/documentStructure/resourceOb
 import invalidApiDocumentArrayAttributesType from './docs/documentStructure/resourceObjects/invalidApiDocumentArrayAttributesType.js';
 
 /**
- * @fileoverview This test suite validates the behavior of the JSON: API Errors.ErrorObjects ruleset
- * when given OpenAPI documents. It tests the different rules defined in jsonapi-errors-error-object.js
+ * @fileoverview This test suite validates the behavior of the JSON: API DocumentStructure.ResourceObjects ruleset
+ * when given OpenAPI documents. It tests the different rules defined in jsonapi-document-structure-resource-objects.js
  * against various OpenAPI documents that are valid based on JSON: API standards
  * 
  * The tests leverage several helper methods:
- *  - `setupSpectralBeforeEach`: Creates a beforeEach function for Mocha tests, setting up Spectral with a given ruleset and enabling specific rules.
+ *  - `setupSpectralBeforeEach`: Creates a beforeEach function for Mocha tests, setting up Spectral with a given ruleset
+ *      and enabling specific rules.
  *  - `handleSpectralResults`: Filters and handles the results of the spectral run.
- *  - `processErrors`: Processes and logs errors, specifically handling AggregateErrors separately. This function checks if the provided error is an instance of AggregateError. If so, it iterates over each individual error within the aggregate and logs them separately. For all other types of errors, it logs them as unexpected errors. This utility is particularly useful for handling and debugging multiple errors that can occur during Spectral setup or execution.
- *  - `resolveRef`: Recursively resolves $ref references in an OpenAPI document. This function handles objects and arrays, resolving all $ref references found within. It supports nested structures and arrays, handles circular references, and removes resolved references from the components section if they are no longer needed.
+ *  - `processErrors`: Processes and logs errors, specifically handling AggregateErrors separately. This function checks
+ *      if the provided error is an instance of AggregateError. If so, it iterates over each individual error within the
+ *      aggregate and logs them separately. For all other types of errors, it logs them as unexpected errors. This utility
+ *      is particularly useful for handling and debugging multiple errors that can occur during Spectral setup or execution.
+ *  - `resolveRef`: Recursively resolves $ref references in an OpenAPI document. This function handles objects and arrays,
+ *      resolving all $ref references found within. It supports nested structures and arrays, handles circular references,
+ *      and removes resolved references from the components section if they are no longer needed.
  * 
  * The suite uses Mocha for test execution and Chai for assertions.
  * 


### PR DESCRIPTION
This commit addresses several spelling mistakes found in the changes for API-21 Resource Object feature, improving clarity and readability.