### PR TITLE
API-23 DocumentStructure.Resource.Fields

### DIFF
--- a/cliTest/documentStructure/resourceObjects/fields/failing-rules.yaml
+++ b/cliTest/documentStructure/resourceObjects/fields/failing-rules.yaml
@@ -1,42 +1,19 @@
-# This OpenAPI Document provides a way of testing rulesets using Spectrals CLI Command. Covered rulesets include:
-#   - `jsonapi-errors-error-object.js`
-#   - `jsonapi-document-structure-resource-objects.js`
-#   - `jsonapi-document-structure-resource-attributes.js`
-#   - `jsonapi-document-structure-resource-identification.js`
-#   - `jsonapi-document-structure-resource-fields.js`
+# This OpenAPI Document provides a way of testing rulesets using using Spectrals CLI Command. Covered ruleset include:
+#   - `jsonapi-document-structure-resource-sttributes.js` 
 #
 # Usage (From Repo Root Location):
-#   - spectral lint cliTest/passing-rules.yaml --ruleset rules/jsonapi-errors-error-object.js --verbose
-#   - spectral lint cliTest/passing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-objects.js --verbose
-#   - spectral lint cliTest/passing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-attributes.js --verbose
-#   - spectral lint cliTest/passing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-identification.js --verbose
-#   - spectral lint cliTest/passing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-fields.js --verbose
+#   spectral lint cliTest/documentStructure/resourceObjects/fields/failing-rules.yaml --ruleset rules/jsonapi-document-structure-resource-fields.js --verbose
 #
-# This document will generate `0 errors` as expected for each ruleset ran
+# This document will generate `1 errors` as expected for each rule.
 openapi: 3.1.0
 info:
   title: OpenAPI Management Template
   description: |-
-    This API manages information pertaining to users
+    This API manages information pertaining to users and articles
     which is adhereing to JSON:API v1.0 standards. The goal of this template is
     to provide a universal temaplte for testing all of the JSON:API v1.0
-    specifications. This document adheres to the following sections:
-      - ContentNegotiation.ClientResponsibilities
-      - ContentNegotiation.ServerResponsibilities
-      - DocumentStructure
-      - DocumentStructure.TopLevel
-      - DocumentStructure.ResourceObjects
-      - DocumentStructure.ResourceObjects.Attributes
-      - DocumentStructure.ResourceObjects.Identification
-      - DocumentStructure.ResourceObjects.Fields
-      - DocumentStructure.Links
-      - DocumentStructure.MetaInformation
-      - DocumentStructure.MemberNames
-      - FetchingData.Sorting
-      - FetchingData.Pagination
-      - FetchingData.Filtering
-      - Errors.ProcessingErrors
-      - Errors.ErrorObjects
+    specifications. This is to generate a failing scenario for the following section:
+      - DocumentStructure.ResourceObjects.fields
   version: 1.2.2
 servers:
   - url: https://api.template.com/v1
@@ -103,6 +80,9 @@ paths:
                         relationships:
                           type: object
                           properties:
+                            # Inserting an `id` field to trigger rule `document-structure-resource-fields-no-type-or-id`
+                            id:
+                              type: string
                             posts:
                               type: object
                               properties:

--- a/rules/jsonapi-document-structure-resource-fields.js
+++ b/rules/jsonapi-document-structure-resource-fields.js
@@ -1,0 +1,33 @@
+// Document Structure - Resource Objects - https://jsonapi.org/format/1.0/#document-resource-object-fields
+
+// All rules in the file MUST have corresponding tests
+
+import { falsy } from '@stoplight/spectral-functions';
+
+export default {
+  documentationUrl: 'https://jsonapi.org/format/1.0/#document-resource-object-fields',
+  rules: {
+
+    /**
+     * Ensures that no fields are directly named `type` or `id`, which are reserved per
+     * JSON:API v1.0
+     */
+    'document-structure-resource-fields-no-type-or-id': {
+      description: 'Ensure that `type` and `id` are not used as field names in `attributes` or `relationships`',
+      message: `{{path}} - {{description}}`,
+      severity: 'error',
+      given: "$.paths..[?(@property == 'responses' || @property == 'requestBody')]..content['application/vnd.api+json'].schema.properties.data..[?(@property == 'attributes' || @property == 'relationships')].properties",
+      then: [
+        {
+          field: 'id',
+          function: falsy
+        },
+        {
+          field: 'type',
+          function: falsy
+        }
+      ]
+    }
+
+  }
+};

--- a/rules/jsonapi-document-structure-ruleset.yaml
+++ b/rules/jsonapi-document-structure-ruleset.yaml
@@ -15,3 +15,4 @@ extends:
   - jsonapi-document-structure-resource-objects.js
   - jsonapi-document-structure-resource-identification.js
   - jsonapi-document-structure-resource-attributes.js
+  - jsonapi-document-structure-resource-fields.js

--- a/test/docs/documentStructure/resourceObjects/fields/invalidApiDocumentNoTypeOrId.js
+++ b/test/docs/documentStructure/resourceObjects/fields/invalidApiDocumentNoTypeOrId.js
@@ -1,0 +1,848 @@
+/* eslint-env mocha */
+/* eslint-disable quotes */
+const invalidApiDocumentNoTypeOrId = {
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI Management Template",
+    "description": "This API manages information pertaining to users\nwhich is adhereing to JSON:API v1.0 standards. The goal of this template is\nto provide a universal temaplte for testing all of the JSON:API v1.0\nspecifications. This document adheres to the following sections:\n  - ContentNegotiation.ClientResponsibilities\n  - ContentNegotiation.ServerResponsibilities\n  - DocumentStructure\n  - DocumentStructure.TopLevel\n  - DocumentStructure.ResourceObjects\n  - DocumentStructure.ResourceObjects.Attributes\n  - DocumentStructure.Links\n  - DocumentStructure.MetaInformation\n  - DocumentStructure.MemberNames\n  - FetchingData.Sorting\n  - FetchingData.Pagination\n  - FetchingData.Filtering\n  - Errors.ProcessingErrors\n  - Errors.ErrorObjects",
+    "version": "1.2.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.template.com/v1"
+    }
+  ],
+  "x-jsonapi-object": {
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "string"
+      },
+      "meta": {
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "List all users",
+        "description": "Retrieve a list of users with pagination and optional filters for sorting and searching.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A list of users",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserListResponse"
+                },
+                "examples": {
+                  "userListExample": {
+                    "summary": "Example response for user list",
+                    "value": {
+                      "data": [
+                        {
+                          "type": "users",
+                          "id": "1",
+                          "attributes": {
+                            "name": "John Doe",
+                            "email": "john@example.com"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Example of a bad request error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-102",
+                          "status": "400",
+                          "title": "Bad Request",
+                          "detail": "The request is invalid."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error - Indicates a server-side error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "internalServerErrorExample": {
+                    "summary": "Example of an internal server error response",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-500",
+                          "status": "500",
+                          "title": "Internal Server Error",
+                          "detail": "The server encountered an unexpected condition that prevented it from fulfilling the request."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page[number]",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "description": "Page number for pagination"
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 20
+            },
+            "description": "Number of items per page"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter string to narrow down the search"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Sorting criteria. E.g., `name,-email` for ascending by name and descending by email."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated list of fields to include in the response."
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Create a new user",
+        "requestBody": {
+          "description": "Payload to create a new user, containing user details.",
+          "required": true,
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "New user created",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Indicates that the server cannot process the request due to a client error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Example of a bad request error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-701",
+                          "status": "400",
+                          "title": "Bad Request",
+                          "detail": "The request could not be processed due to malformed syntax.",
+                          "links": {
+                            "about": "https://api.usermanagement.com/docs/errors/400"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Indicates a server-side error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Example of a bad request error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-902",
+                          "status": "500",
+                          "title": "Internal Server Error",
+                          "detail": "The server encountered an unexpected condition.",
+                          "links": {
+                            "about": "https://api.usermanagement.com/docs/errors/400"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userId}": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Get User by ID",
+        "security": [],
+        "description": "Retrieves information for a specific user by their ID.",
+        "operationId": "getUserById",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "description": "Unique identifier of the user",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Details of a user",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example",
+                    "value": {
+                      "data": {
+                        "id": "12345",
+                        "type": "user",
+                        "attributes": {
+                          "name": "John Doe",
+                          "email": "john.doe@example.com"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "Example of a not found error",
+                    "value": {
+                      "errors": {
+                        "id": "error-444",
+                        "status": "404",
+                        "title": "Not Found",
+                        "detail": "The requested resource was not found.",
+                        "links": {
+                          "about": "https://api.usermanagement.com/docs/errors/404"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Example of a bad request error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-032",
+                          "status": "500",
+                          "title": "Internal Server Error",
+                          "detail": "The server encountered an unexpected condition.",
+                          "links": {
+                            "about": "https://api.usermanagement.com/docs/errors/500"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Update a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Payload to update an existing user.",
+          "required": true,
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequestExample": {
+                    "summary": "Example of a Bad Request response",
+                    "value": {
+                      "errors": [
+                        {
+                          "status": 400,
+                          "title": "Bad Request",
+                          "detail": "The request payload is invalid. Please check the request data."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Example of a bad request error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-032",
+                          "status": "500",
+                          "title": "Internal Server Error",
+                          "detail": "The server encountered an unexpected condition.",
+                          "links": {
+                            "about": "https://api.usermanagement.com/docs/errors/500"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The user was successfully deleted."
+          },
+          "404": {
+            "description": "The specified user was not found.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "notFoundError": {
+                    "summary": "Example of a 404 Not Found error",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-123",
+                          "status": "404",
+                          "title": "Not Found",
+                          "detail": "The user with the specified ID was not found.",
+                          "links": {
+                            "about": "https://api.usermanagement.com/docs/errors/404"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error - Indicates a server-side error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonApiError"
+                },
+                "examples": {
+                  "internalServerErrorExample": {
+                    "summary": "Example of an internal server error response",
+                    "value": {
+                      "errors": [
+                        {
+                          "id": "error-500",
+                          "status": "500",
+                          "title": "Internal Server Error",
+                          "detail": "The server encountered an unexpected condition that prevented it from fulfilling the request."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "required": [
+          "id",
+          "type"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the user"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the resource (users)"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/UserAttributes"
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              // Inserting a `id` field to generate a failing scenario for rule `document-structure-resource-fields-no-type-or-id`
+              "id": {
+                "type": "string"
+              },
+              // Inserting a `type` field to generate a failing scenario for rule `document-structure-resource-fields-no-type-or-id`
+              "type": {
+                "type": "string"
+              },
+              "posts": {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            }
+          }
+        }
+      },
+      "UserResponse": {
+        "type": "object",
+        "description": "Response schema for a single user or a newly created user.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/User"
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedResource"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          }
+        }
+      },
+      "UserListResponse": {
+        "type": "object",
+        "description": "Response schema for a list of users with pagination details.",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          }
+        }
+      },
+      "UserRequest": {
+        "type": "object",
+        "description": "Request schema for creating a new user.",
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "type",
+              "attributes"
+            ],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "attributes": {
+                "$ref": "#/components/schemas/UserAttributes"
+              }
+            }
+          }
+        }
+      },
+      "UserUpdateRequest": {
+        "type": "object",
+        "description": "Request schema for updating an existing user's details.",
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "attributes": {
+                "$ref": "#/components/schemas/UserAttributes"
+              }
+            }
+          }
+        }
+      },
+      "UserAttributes": {
+        "type": "object",
+        "required": [
+          "name",
+          "email"
+        ],
+        "properties": {
+          // Inserting a `id` field to generate a failing scenario for rule `document-structure-resource-fields-no-type-or-id`
+          "id": {
+            "type": "string"
+          },
+          // Inserting a `type` field to generate a failing scenario for rule `document-structure-resource-fields-no-type-or-id`
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the user"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Email address of the user, must follow standard email format."
+          },
+          "role": {
+            "type": "string",
+            "description": "Role of the user in the system"
+          }
+        }
+      },
+      "RelationshipLinks": {
+        "type": "object",
+        "properties": {
+          "self": {
+            "type": "string",
+            "format": "uri"
+          },
+          "related": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "RelatedResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/UserAttributes"
+          }
+        }
+      },
+      "Meta": {
+        "type": "object",
+        "properties": {
+          "totalCount": {
+            "type": "integer",
+            "description": "Total number of resources available."
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of the last update."
+          }
+        }
+      },
+      "PaginationLinks": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "The link to the first page of data. Null if not available."
+          },
+          "last": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "The link to the last page of data. Null if not available."
+          },
+          "prev": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "The link to the previous page of data. Null if not available."
+          },
+          "next": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "The link to the next page of data. Null if not available."
+          }
+        }
+      },
+      "JsonApiError": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorObject"
+            }
+          }
+        }
+      },
+      "ErrorObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "about": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          
+          /**
+           * Commonly used HTTP status codes:
+           * 
+           * `400` Bad Request: The request was unacceptable, often due o missing a required parameter
+           * `401` Unauthorized: No valid authentication credentials provided.
+           * `403` Forbidden: The client does not have access rights to the content.
+           * `404` Not Found: The requested resource does not exist.
+           * `406` Not Acceptable: The requested format is not available.
+           * `409` Conflict: The request could not be completed due to a conflict.
+           * `422` Unprocessable Entity: The request was well-formed but was unable to be followed due to semantic errors.
+           * `500` Internal Server Error: A generic error message for unexpected server errors.
+           * `502` Bad Gateway: The server received an invalid response from the upstream server.
+           * `503` Service Unavailable: The server is currently unavailable (overloaded or down).
+           */
+          "status": {
+            "type": "string",
+            "enum": [
+              "400",
+              "401",
+              "403",
+              "404",
+              "405",
+              "406",
+              "409",
+              "422",
+              "500",
+              "502",
+              "503"
+            ],
+            "description": "HTTP status code applicable to this error, given as a string value."
+          },
+          "code": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "pointer": {
+                "type": "string"
+              },
+              "parameter": {
+                "type": "string"
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT Bearer token authentication"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY",
+        "description": "API Key based authentication"
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    },
+    {
+      "ApiKeyAuth": []
+    }
+  ]
+};
+
+export default invalidApiDocumentNoTypeOrId;

--- a/test/jsonapi-document-structure-resource-fields.test.js
+++ b/test/jsonapi-document-structure-resource-fields.test.js
@@ -1,0 +1,159 @@
+/* eslint-env mocha */
+import { JSONPath } from 'jsonpath-plus';
+
+// Rules to test
+import ruleset from '../rules/jsonapi-document-structure-resource-fields.js';
+
+// Helper Functions
+import { resolveRef } from './utils/refResolver.js';
+import { handleSpectralResults } from './utils/handleSpectralResults.js';
+import { processErrors } from './utils/processErrors.js';
+import { debugLog, debugError, debugInfo, debugDebug } from './utils/debugUtils.js';
+import { setupSpectralBeforeEach } from './utils/setupSpectralBeforeEach.js';
+
+// OpenAPI Documents
+import invalidApiDocumentNoTypeOrId from './docs/documentStructure/resourceObjects/fields/invalidApiDocumentNoTypeOrId.js';
+
+/**
+ * @fileoverview This test suite validates the behavior of the JSON: API DocumentStructure.Resource.Fields ruleset
+ * when given OpenAPI documents. It tests the different rules defined in jsonapi-document-structure-resource-fields.js
+ * against various OpenAPI documents that are valid based on JSON: API v1.0 standards
+ * 
+ * The tests leverage several helper methods:
+ *  - `setupSpectralBeforeEach`: Creates a beforeEach function for Mocha tests, setting up Spectral with a given ruleset
+ *      and enabling specific rules.
+ *  - `handleSpectralResults`: Filters and handles the results of the spectral run.
+ *  - `processErrors`: Processes and logs errors, specifically handling AggregateErrors separately. This function checks if
+ *      the provided error is an instance of AggregateError. If so, it iterates over each individual error within the aggregate
+ *      and logs them separately. For all other types of errors, it logs them as unexpected errors. This utility is particularly
+ *      useful for handling and debugging multiple errors that can occur during Spectral setup or execution.
+ *  - `resolveRef`: Recursively resolves $ref references in an OpenAPI document. This function handles objects and arrays,
+ *      resolving all $ref references found within. It supports nested structures and arrays, handles circular references, and
+ *      keeps resolved references from the components section for when they are needed at a later time.
+ * 
+ * The suite uses Mocha for test execution and Chai for assertions.
+ * 
+ * Each ruleset has three test cases that focuses on the following:
+ *   - Validate the JSONPath Expression for that rule
+ *   - Generate a negative case scenario for that rule
+ *   - Generate a positive case scenario for that rule
+ */
+describe('jsonapi-document-structure-resource-fields ruleset:', function documentStructureResourceFieldsSuite() {
+
+  let dereferenceValidApiDocument;
+
+  before(function () {
+
+    // Access the globally dereferenced document
+    dereferenceValidApiDocument = global.dereferencedValidOpenApiDocument;
+    
+  });
+
+  /**
+   * Ruleset: document-structure-resource-fields-no-type-or-id
+   */
+  describe('document-structure-resource-fields-no-type-or-id:', function documentStructureResourceFieldsNoTypeOrId() {
+
+    const testingRuleName = 'document-structure-resource-fields-no-type-or-id';
+
+    beforeEach(setupSpectralBeforeEach(ruleset, [testingRuleName]));
+
+    it('the json path expression should find the correct paths from the given document', function documentStructureResourceFieldsNoTypeOrIdPath() {
+
+      try {
+
+        // debugDebug(`Dereferenced Document: ${JSON.stringify(dereferenceValidApiDocument, null, 2)}`);
+
+        const jsonPathExpression = ruleset.rules[testingRuleName].given;
+        debugDebug(`JSONPath Expression: ${jsonPathExpression}`);
+        const expectedExpressionPaths = [
+          { expected: dereferenceValidApiDocument.paths['/users'].get.responses[200].content['application/vnd.api+json'].schema.properties.data.items.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users'].get.responses[200].content['application/vnd.api+json'].schema.properties.data.items.properties.relationships.properties },
+          { expected: dereferenceValidApiDocument.paths['/users'].post.requestBody.content['application/vnd.api+json'].schema.properties.data.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users'].post.responses[201].content['application/vnd.api+json'].schema.properties.data.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users'].post.responses[201].content['application/vnd.api+json'].schema.properties.data.properties.relationships.properties },
+          { expected: dereferenceValidApiDocument.paths['/users/{userId}'].get.responses[200].content['application/vnd.api+json'].schema.properties.data.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users/{userId}'].get.responses[200].content['application/vnd.api+json'].schema.properties.data.properties.relationships.properties },
+          { expected: dereferenceValidApiDocument.paths['/users/{userId}'].put.requestBody.content['application/vnd.api+json'].schema.properties.data.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users/{userId}'].put.responses[200].content['application/vnd.api+json'].schema.properties.data.properties.attributes.properties },
+          { expected: dereferenceValidApiDocument.paths['/users/{userId}'].put.responses[200].content['application/vnd.api+json'].schema.properties.data.properties.relationships.properties }
+        ];
+
+        expectedExpressionPaths.forEach((path, index) => {
+
+          const result = JSONPath({ path: jsonPathExpression,
+            json: dereferenceValidApiDocument });
+
+          debugInfo(`Element ${index + 1} found from JSONPath Expression: \x1b[32m${JSON.stringify(result[index], null, 2)}`);
+
+          // Check if the number of results matches the expected number
+          expect(result.length).to.equal(expectedExpressionPaths.length, `\x1b[31mExpected ${expectedExpressionPaths.length} elements to match in the OpenAPI Document.\x1b[0m\n`);
+          
+          // Check if each result matches the corresponding expected path
+          expect(result[index]).to.deep.equal(path.expected, `\x1b[31mThe wrong JSONPath Expression was provided in expected path: ${index + 1}\x1b[0m`);
+
+        });
+        
+      } catch (error) {
+    
+        processErrors(error);
+        
+      }
+      
+    });
+
+    it(`the rule should return "${testingRuleName}" errors, if ${ruleset.rules[testingRuleName].description} is false`, async function documentStructureResourceFieldsNoTypeOrIdFailure() {
+
+      try {
+    
+        const dereferencedOpenApiDocument = resolveRef(invalidApiDocumentNoTypeOrId, invalidApiDocumentNoTypeOrId);
+
+        // debugDebug(`Dereferenced Document: ${JSON.stringify(dereferencedOpenApiDocument,null,2)}`);
+
+        const relevantResults = await handleSpectralResults(this.spectral, dereferencedOpenApiDocument, testingRuleName);
+    
+        debugLog(`  Confirmed Errors:`);
+        debugLog(`\x1b[33m    - ${relevantResults.length}\x1b[0m\n`);
+
+        relevantResults.forEach((result) => {
+
+          debugError(`\x1b[32mResults for '\x1b[33m${testingRuleName}\x1b[32m':\x1b[36m ${JSON.stringify(result, ['message', 'path'], 2)} \x1b[0m\n`);
+
+        });
+
+        const confirmedErrors = 20;
+        const errorMessage = `\x1b[31mError count should be ${confirmedErrors}.\x1b[0m`;
+
+        expect(relevantResults.length).to.equal(confirmedErrors, errorMessage);
+        
+      } catch (error) {
+    
+        processErrors(error);
+        
+      }
+      
+    });
+
+    it('the rule should pass with NO errors', async function documentStructureResourceFieldsNoTypeOrIdPassing() {
+
+      try {
+    
+        const relevantResults = await handleSpectralResults(this.spectral, dereferenceValidApiDocument, testingRuleName);
+    
+        debugLog(`  Confirmed Errors:`);
+        debugLog(`\x1b[33m    - ${relevantResults.length}\x1b[0m\n`);
+
+        const errorMessage = `\x1b[31mError count should be 0, ${ruleset.rules[testingRuleName].description}\x1b[0m`;
+        expect(relevantResults.length).to.equal(0, errorMessage);
+        
+      } catch (error) {
+    
+        processErrors(error);
+        
+      }
+      
+    });
+
+  });
+
+});


### PR DESCRIPTION
Added New Spectral Rules for JSON:API v1.0 DocumentStructure.ResourceObjects.Fields

This introduces a new Spectral rule specifically tailored for validation JSON:API v1.0 Document Structure - Resource Objects - Fields within an OpenAPI Document. Key Highlights Include:

- Creation of a Spectral rule to ensure compliance with JSON:API v1.0 standards, focusing on `Resource Objects - Fields` specifications.
- Ensuring the `Resource Objects` members `attributes` and `relationships` do not contain a `type` or `id` field.

These additions significantly improve our capability to automatically validate and ensure the consistency of API responses with the JSON:API v1.0 standard.