### PR TITLE
Updated tests to support Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "spectral rules for json:api",
   "scripts": {
-    "test": "spectral lint examples/valid/* -r ./.spectral.yml",
+    "test": "npx spectral lint examples/valid/* -r ./.spectral.yml",
     "prepare": "husky install"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "spectral rules for json:api",
   "scripts": {
-    "test": "./node_modules/.bin/spectral lint examples/valid/* -r ./.spectral.yml",
+    "test": "spectral lint examples/valid/* -r ./.spectral.yml",
     "prepare": "husky install"
   },
   "repository": {


### PR DESCRIPTION
As per issue https://github.com/jmlue42/spectral-jsonapi-ruleset/issues/75 , the existing test failed to run on Windows. The revised npm test command works on both Windows and Mac, as the removed text (node_modules/.bin) is automatically inserted at the beginning of the PATH before executing.